### PR TITLE
Handle Static Feed Redirects from OpenMobilityData

### DIFF
--- a/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
@@ -35,6 +35,7 @@ public class CronService {
         try {
             log.info("Gathering Feeds...");
             var feeds = gtfsFeedAggregator.gatherRTFeeds();
+            var oldFeeds = agencyFeedRepository.getAllAgencyFeeds();
             log.info("Gathered Feeds. Writing feeds to table...");
             agencyFeedRepository.removeAllAgencyFeeds();
             agencyFeedRepository.writeAgencyFeeds(feeds);

--- a/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
@@ -35,7 +35,6 @@ public class CronService {
         try {
             log.info("Gathering Feeds...");
             var feeds = gtfsFeedAggregator.gatherRTFeeds();
-            var oldFeeds = agencyFeedRepository.getAllAgencyFeeds();
             log.info("Gathered Feeds. Writing feeds to table...");
             agencyFeedRepository.removeAllAgencyFeeds();
             agencyFeedRepository.writeAgencyFeeds(feeds);

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
@@ -21,11 +21,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class GtfsRealtimeParserService {
     public static final String UNKNOWN_ROUTE = "UNKNOWN_ROUTE";
+    public static final List<GtfsRealtime.TripDescriptor.ScheduleRelationship> ignorableScheduleRelationshipEnums =
+            List.of(CANCELED);
     private final GtfsStaticRepository repository;
 
     /**
@@ -35,7 +39,7 @@ public class GtfsRealtimeParserService {
      * @return true if all required fields are not null
      */
     private static boolean validateRequiredFields(GtfsRealtime.TripUpdate entity) {
-        return true;
+        return !ignorableScheduleRelationshipEnums.contains(entity.getTrip().getScheduleRelationship());
     }
 
     @NotNull


### PR DESCRIPTION
To gather all of our Realtime feeds, we poll openMobilityData. OpenMobilityData has redirects, so that new links can be used over time. While we accounted for this for the Realtime feeds, we did not account for the rt-static mapping for this new data to point to old static entries. This commit addresses that.

Also addressed with this commit is an issue with metro transit sending a bunch of nonsensical cancelled trips in their Realtime feed, which makes the system think that the feed is outdated and cancel polling from it.