### PR TITLE
Refactor how we retry feeds

### DIFF
--- a/src/main/java/com/doug/projects/transitdelayservice/repository/GtfsStaticRepository.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/repository/GtfsStaticRepository.java
@@ -135,6 +135,10 @@ public class GtfsStaticRepository {
         return this.findAllRoutes(agencyId).map(l -> l.stream().map(GtfsStaticData::getRouteName).distinct().toList());
     }
 
+    private static boolean checkIdAndRouteName(GtfsStaticData staticData) {
+        return staticData != null && staticData.getId() != null && staticData.getRouteName() != null;
+    }
+
     public Map<String, String> mapRouteIdsToRouteName(String agencyId, List<String> routeIds) {
         if (StringUtils.isBlank(agencyId) || CollectionUtils.isEmpty(routeIds)) return Collections.emptyMap();
         List<String> uniqueRouteIds = routeIds.stream().distinct().toList();
@@ -142,7 +146,7 @@ public class GtfsStaticRepository {
             BatchGetItemEnhancedRequest enhancedRequest = BatchGetItemEnhancedRequest.builder().readBatches(generateReadBatches(agencyId, chunkList, GtfsStaticData.TYPE.ROUTE.getName())).build();
             return Flux.from(enhancedAsyncClient.batchGetItem(enhancedRequest))
                     .flatMapIterable(p -> p.resultsForTable(table))
-                    .filter(Objects::nonNull)
+                    .filter(GtfsStaticRepository::checkIdAndRouteName)
                     .toStream();
         }).collect(Collectors.toMap(GtfsStaticData::getId, GtfsStaticData::getRouteName));
     }
@@ -154,7 +158,7 @@ public class GtfsStaticRepository {
             BatchGetItemEnhancedRequest enhancedRequest = BatchGetItemEnhancedRequest.builder().readBatches(generateReadBatches(agencyId, chunkList, GtfsStaticData.TYPE.TRIP.getName())).build();
             return Flux.from(enhancedAsyncClient.batchGetItem(enhancedRequest))
                     .flatMapIterable(p -> p.resultsForTable(table))
-                    .filter(Objects::nonNull)
+                    .filter(GtfsStaticRepository::checkIdAndRouteName)
                     .toStream();
         }).collect(Collectors.toMap(GtfsStaticData::getId, GtfsStaticData::getRouteName));
     }

--- a/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
@@ -28,7 +28,7 @@ public class CronService {
     @Value("${doesRealtimeCronRun}")
     private Boolean doesRealtimeCronRun;
 
-    @Scheduled(fixedRate = 1, timeUnit = TimeUnit.DAYS)
+    @Scheduled(fixedRate = 30, timeUnit = TimeUnit.DAYS)
     public void writeFeeds() {
         if (!doesAgencyCronRun)
             return;

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
@@ -147,7 +147,10 @@ public class GtfsRealtimeParserService {
             return doRPCRequest(feed, feedId, realtimeUrl);
         } catch (IOException e) {
             log.error("Error reading realtime feed from id: {}, url: {}, message: {}", feedId, realtimeUrl, e.getMessage());
-            return AgencyRealtimeResponse.builder().feed(feed).feedStatus(AgencyFeed.Status.UNAVAILABLE).build();
+            return AgencyRealtimeResponse.builder()
+                    .feed(feed)
+                    .feedStatus(AgencyFeed.Status.TIMEOUT)
+                    .build();
         }
     }
 


### PR DESCRIPTION
Marking all feeds as active every day is proving expensive, costing ~100 bucks a month (thank god for aws credits)

To fix this, I've changed our retry logic to retry a feed 3 times, and if it fails, mark it as unavailable for a month.

This might require more manual intervention, but it is worth it to save money.