### PR TITLE
Use Threadpool for Realtime Polling

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value

--- a/src/main/java/com/doug/projects/transitdelayservice/TransitDelayServiceApplication.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/TransitDelayServiceApplication.java
@@ -13,6 +13,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
 @SpringBootApplication
 @EnableScheduling
 @EnableWebFlux
@@ -47,5 +50,10 @@ public class TransitDelayServiceApplication {
                                         .defaultCodecs().maxInMemorySize((1000 * 1000 * 1024))).build())
                 .codecs(clientCodecConfigurer -> clientCodecConfigurer.defaultCodecs()
                         .maxInMemorySize(1000 * 1000 * 1024)).build();
+    }
+
+    @Bean("realtime")
+    public Executor realtimeExecutor() {
+        return Executors.newFixedThreadPool(10);
     }
 }

--- a/src/main/java/com/doug/projects/transitdelayservice/controller/AgenciesController.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/controller/AgenciesController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -26,8 +27,8 @@ public class AgenciesController {
 
     @GetMapping("/v1/agencies/active")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
-    public ResponseEntity<List<AgencyFeed>> getActiveAgencies() {
-        return ResponseEntity.ok(agencyFeedRepository.getAgencyFeedsByStatus(AgencyFeed.Status.ACTIVE));
+    public Flux<AgencyFeed> getActiveAgencies() {
+        return agencyFeedRepository.getFeedFluxByStatus(AgencyFeed.Status.ACTIVE);
     }
 
     @GetMapping("/v1/agencies/{feedId}")

--- a/src/main/java/com/doug/projects/transitdelayservice/entity/dynamodb/AgencyFeed.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/entity/dynamodb/AgencyFeed.java
@@ -3,6 +3,7 @@ package com.doug.projects.transitdelayservice.entity.dynamodb;
 import lombok.*;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 
 @DynamoDbBean
@@ -11,9 +12,10 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortK
 @NoArgsConstructor
 @Builder
 public class AgencyFeed {
+    public static final String ID_INDEX = "id-index";
     @Getter(onMethod = @__(@DynamoDbPartitionKey))
     private String status;
-    @Getter(onMethod = @__(@DynamoDbSortKey))
+    @Getter(onMethod = @__({@DynamoDbSortKey, @DynamoDbSecondaryPartitionKey(indexNames = ID_INDEX)}))
     private String id;
     private String name;
     private String realTimeUrl;

--- a/src/test/java/com/doug/projects/transitdelayservice/service/CronServiceTest.java
+++ b/src/test/java/com/doug/projects/transitdelayservice/service/CronServiceTest.java
@@ -14,6 +14,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import static com.doug.projects.transitdelayservice.entity.dynamodb.AgencyFeed.Status.ACTIVE;
 import static org.mockito.Mockito.*;
@@ -32,6 +34,7 @@ class CronServiceTest {
     private AgencyRouteTimestampRepository routeTimestampRepository;
     @Mock
     private GtfsRetryOnFailureService retryOnFailureService;
+    private final Executor rtExec = Executors.newSingleThreadExecutor();
 
     private static List<AgencyFeed> getAgencyFeedList() {
         return List.of(getAgencyFeedActive());
@@ -70,6 +73,7 @@ class CronServiceTest {
                 .thenReturn(getAgencyFeedList());
         when(rtResponseService.convertFromAsync(eq(getAgencyFeedActive()), anyInt()))
                 .thenReturn(CompletableFuture.completedFuture(getResponse()));
+        ReflectionTestUtils.setField(cronService, "realtimeExecutor", rtExec);
         cronService.writeGtfsRealtimeData();
         verify(agencyFeedRepository, times(1)).getAgencyFeedsByStatus(eq(ACTIVE));
         verify(rtResponseService, times(1)).convertFromAsync(eq(getAgencyFeedActive()), anyInt());


### PR DESCRIPTION
In prod, we were seeing an issue with memory because the threads were not being cleaned up / pooled as expected. To resolve this, we added a new fixed thread pool to prevent issues like this in the future.