### PR TITLE
Add gtfsStatic stopTime arrival/departure interpolation

### DIFF
--- a/src/main/java/com/doug/projects/transitdelayservice/TransitDelayServiceApplication.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/TransitDelayServiceApplication.java
@@ -56,4 +56,14 @@ public class TransitDelayServiceApplication {
     public Executor realtimeExecutor() {
         return Executors.newFixedThreadPool(10);
     }
+
+    @Bean("retry")
+    public Executor retryExecutor() {
+        return Executors.newFixedThreadPool(10);
+    }
+
+    @Bean("dynamoWriting")
+    public Executor dynamoExecutor() {
+        return Executors.newFixedThreadPool(5);
+    }
 }

--- a/src/main/java/com/doug/projects/transitdelayservice/entity/dynamodb/GtfsStaticData.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/entity/dynamodb/GtfsStaticData.java
@@ -1,7 +1,6 @@
 package com.doug.projects.transitdelayservice.entity.dynamodb;
 
-import lombok.Data;
-import lombok.Getter;
+import lombok.*;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
@@ -11,6 +10,9 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortK
 
 @Data
 @DynamoDbBean
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class GtfsStaticData {
     public static final String AGENCY_TYPE_INDEX = "agencyType-index";
     //{agency_id}:{type}

--- a/src/main/java/com/doug/projects/transitdelayservice/repository/GtfsStaticRepository.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/repository/GtfsStaticRepository.java
@@ -100,24 +100,6 @@ public class GtfsStaticRepository {
         }
     }
 
-    private void retryUnprocessed(List<GtfsStaticData> data, BatchWriteResult r) {
-        if (r == null) {
-            log.error("Timeout writing to dynamoDB. Retrying...");
-            try {
-                Thread.sleep(5000);
-            } catch (InterruptedException e) {
-                log.error("Sleeping interrupted while retrying!");
-                Thread.currentThread().interrupt();
-            }
-            asyncBatchWrite(data).join();
-            return;
-        }
-        if (!r.unprocessedPutItemsForTable(table).isEmpty()) {
-            log.error("Unprocessed items: {}", r.unprocessedPutItemsForTable(table));
-            asyncBatchWrite(r.unprocessedPutItemsForTable(table)).join();
-        }
-    }
-
     public Mono<List<GtfsStaticData>> findAllRoutes(String agencyId) {
         QueryConditional queryConditional = QueryConditional.keyEqualTo(k ->
                 k.partitionValue(agencyId + ":" + GtfsStaticData.TYPE.ROUTE.getName()));

--- a/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
@@ -24,8 +24,10 @@ public class CronService {
     private final GtfsRealtimeParserService rtResponseService;
     private final AgencyRouteTimestampRepository routeTimestampRepository;
     private final GtfsRetryOnFailureService retryOnFailureService;
-    @Qualifier("realtime")
-    private final Executor realtimeExecutor;
+    @Qualifier("retry")
+    private final Executor retryExecutor;
+    @Qualifier("dynamoWriting")
+    private final Executor dynamoExecutor;
     @Value("${doesAgencyCronRun}")
     private Boolean doesAgencyCronRun;
     @Value("${doesRealtimeCronRun}")
@@ -61,8 +63,8 @@ public class CronService {
                         .stream()
                         .map(feed ->
                                 rtResponseService.convertFromAsync(feed, 60)
-                                        .thenApplyAsync(retryOnFailureService::reCheckFailures, realtimeExecutor)
-                                        .thenAcceptAsync(routeTimestampRepository::saveAll, realtimeExecutor))
+                                        .thenApplyAsync(retryOnFailureService::reCheckFailures, retryExecutor)
+                                        .thenAcceptAsync(routeTimestampRepository::saveAll, dynamoExecutor))
                         .toArray(CompletableFuture[]::new);
 
         CompletableFuture.allOf(allFutures).join();

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
@@ -298,6 +298,10 @@ public class GtfsRealtimeParserService {
         fileStream.close();
         if (containsNullDelay(routeTimestampList)) {
             log.error("Feed {} had null delay! Static data may need to be reindexed.", feedId);
+            return AgencyRealtimeResponse.builder()
+                    .feed(feed)
+                    .feedStatus(AgencyFeed.Status.OUTDATED)
+                    .build();
         }
         return AgencyRealtimeResponse.builder()
                 .feed(feed)
@@ -307,6 +311,9 @@ public class GtfsRealtimeParserService {
     }
 
     private boolean containsNullDelay(List<AgencyRouteTimestamp> routeTimestampList) {
-        return routeTimestampList.stream().flatMap(rt -> rt.getBusStatesCopyList().stream()).map(BusState::getDelay).anyMatch(Objects::isNull);
+        return routeTimestampList.stream()
+                .flatMap(rt -> rt.getBusStatesCopyList().stream())
+                .map(BusState::getDelay)
+                .anyMatch(Objects::isNull);
     }
 }

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
@@ -297,7 +297,7 @@ public class GtfsRealtimeParserService {
         log.info("Read {} realtime feed entries from id: {}, url: {}", routeTimestampList.size(), feedId, realtimeUrl);
         fileStream.close();
         if (containsNullDelay(routeTimestampList)) {
-            log.error("Feed {} had null delay! Static data may need to be reindexed.", feedId);
+            log.error("Feed {} had null delay!.", feedId);
             return AgencyRealtimeResponse.builder()
                     .feed(feed)
                     .feedStatus(AgencyFeed.Status.OUTDATED)

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRealtimeParserService.java
@@ -5,7 +5,6 @@ import com.doug.projects.transitdelayservice.entity.dynamodb.AgencyFeed;
 import com.doug.projects.transitdelayservice.entity.dynamodb.AgencyRouteTimestamp;
 import com.doug.projects.transitdelayservice.entity.dynamodb.BusState;
 import com.doug.projects.transitdelayservice.entity.transit.ExpectedBusTimes;
-import com.doug.projects.transitdelayservice.repository.AgencyFeedRepository;
 import com.doug.projects.transitdelayservice.repository.GtfsStaticRepository;
 import com.doug.projects.transitdelayservice.util.TransitDateUtil;
 import com.google.transit.realtime.GtfsRealtime;
@@ -31,6 +30,7 @@ import java.util.stream.Collectors;
 import static com.doug.projects.transitdelayservice.util.UrlRedirectUtil.handleRedirect;
 import static com.doug.projects.transitdelayservice.util.UrlRedirectUtil.isRedirect;
 import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED;
+import static com.google.transit.realtime.GtfsRealtime.TripDescriptor.ScheduleRelationship.SCHEDULED;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 @Service
@@ -41,7 +41,6 @@ public class GtfsRealtimeParserService {
     public static final List<GtfsRealtime.TripDescriptor.ScheduleRelationship> ignorableScheduleRelationshipEnums =
             List.of(CANCELED);
     private final GtfsStaticRepository staticRepository;
-    private final AgencyFeedRepository feedRepository;
     @Qualifier("realtime")
     private final Executor realtimeExecutor;
     private final ExpectedBusTimesService expectedBusTimesService;
@@ -53,7 +52,7 @@ public class GtfsRealtimeParserService {
      * @return true if all required fields are not null
      */
     private static boolean validateRequiredFields(GtfsRealtime.TripUpdate entity) {
-        return !ignorableScheduleRelationshipEnums.contains(entity.getTrip().getScheduleRelationship());
+        return entity.getTrip().getScheduleRelationship().equals(SCHEDULED);
     }
 
     @NotNull

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRetryOnFailureService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRetryOnFailureService.java
@@ -12,7 +12,8 @@ import org.springframework.util.CollectionUtils;
 import java.util.Collections;
 import java.util.List;
 
-import static com.doug.projects.transitdelayservice.entity.dynamodb.AgencyFeed.Status.*;
+import static com.doug.projects.transitdelayservice.entity.dynamodb.AgencyFeed.Status.TIMEOUT;
+import static com.doug.projects.transitdelayservice.entity.dynamodb.AgencyFeed.Status.UNAVAILABLE;
 
 /**
  * Used in the event of a failure when reading static data or realtime data.
@@ -70,7 +71,7 @@ public class GtfsRetryOnFailureService {
                 var realtimeResult = realtimeParserService.convertFromAsync(feed, 240).join();
                 if (realtimeResult.getFeedStatus() != AgencyFeed.Status.ACTIVE) {
                     log.error("Retried reading realtime feed, but was unable to find associated staticData in Dynamo");
-                    updateFeedToStatus(feed, OUTDATED);
+                    updateFeedToStatus(feed, realtimeResult.getFeedStatus());
                 }
             }
             case TIMEOUT, UNAVAILABLE -> {

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRetryOnFailureService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRetryOnFailureService.java
@@ -54,7 +54,7 @@ public class GtfsRetryOnFailureService {
     private void recheckFeedByStatus(AgencyFeed.Status feedStatus, AgencyFeed feed) {
         switch (feedStatus) {
             case ACTIVE -> {
-                //do nothing
+                //re-activate deactivated feeds on success
             }
             case UNAUTHORIZED, DELETED -> {
                 updateFeedToStatus(feed, feedStatus);
@@ -84,10 +84,10 @@ public class GtfsRetryOnFailureService {
         }
     }
 
-    private void updateFeedToStatus(AgencyFeed feed, AgencyFeed.Status status) {
-        log.error("Updating feed {} to {}", feed.getId(), status);
-        feedRepository.removeAgencyFeed(feed);
-        feed.setStatus(String.valueOf(status));
-        feedRepository.writeAgencyFeed(feed);
+    private void updateFeedToStatus(AgencyFeed newFeed, AgencyFeed.Status newStatus) {
+        log.error("Updating feed {} to {}", newFeed.getId(), newStatus);
+        feedRepository.removeAgencyFeed(newFeed);
+        newFeed.setStatus(String.valueOf(newStatus));
+        feedRepository.writeAgencyFeed(newFeed);
     }
 }

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserService.java
@@ -21,6 +21,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,11 +33,13 @@ import java.util.concurrent.TimeUnit;
 
 import static com.doug.projects.transitdelayservice.entity.dynamodb.GtfsStaticData.TYPE.*;
 import static com.doug.projects.transitdelayservice.util.UrlRedirectUtil.handleRedirect;
+import static java.util.stream.Collectors.groupingBy;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class GtfsStaticParserService {
+    private static final DateTimeFormatter departureTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
     private final GtfsStaticRepository gtfsStaticRepository;
     private final AgencyFeedRepository agencyFeedRepository;
 
@@ -195,6 +200,43 @@ public class GtfsStaticParserService {
     }
 
     /**
+     * In some GTFS feeds, the schedule is missing departureTimes.
+     * <br /><br />
+     * For example: 5:00,null,null,5:03,null,null,5:06 would be replaced with 5:00,5:01,5:02,5:03,5:04,5:05,5:06
+     *
+     * @param gtfsList the gtfsList to be modified by this method
+     */
+    public static void interpolateDelay(List<GtfsStaticData> gtfsList) {
+        for (List<GtfsStaticData> sameTripStops : gtfsList.stream().collect(groupingBy(GtfsStaticData::getId)).values()) {
+            int startDepartureIndex = 0;
+            int startArrivalIndex = 0;
+            for (int i = 1; i < sameTripStops.size(); i++) {
+                GtfsStaticData sameTripStop = sameTripStops.get(i);
+                if (sameTripStop.getDepartureTime() != null) {
+                    LocalTime startTime = LocalTime.parse(sameTripStops.get(startDepartureIndex).getDepartureTime());
+                    LocalTime endTime = LocalTime.parse(sameTripStop.getDepartureTime());
+                    Duration difference = Duration.between(startTime, endTime).dividedBy(i - startDepartureIndex);
+                    for (GtfsStaticData gtfsStaticData : sameTripStops.subList(startDepartureIndex + 1, i)) {
+                        gtfsStaticData.setDepartureTime(startTime.plus(difference).toString());
+                        difference = difference.plus(difference);
+                    }
+                    startDepartureIndex = i;
+                }
+                if (sameTripStop.getArrivalTime() != null) {
+                    LocalTime startTime = LocalTime.parse(sameTripStops.get(startArrivalIndex).getArrivalTime());
+                    LocalTime endTime = LocalTime.parse(sameTripStop.getArrivalTime());
+                    Duration difference = Duration.between(startTime, endTime).dividedBy(i - startArrivalIndex);
+                    for (GtfsStaticData gtfsStaticData : sameTripStops.subList(startArrivalIndex + 1, i)) {
+                        gtfsStaticData.setArrivalTime(startTime.plus(difference).format(departureTimeFormatter));
+                        difference = difference.plus(difference);
+                    }
+                    startArrivalIndex = i;
+                }
+            }
+        }
+    }
+
+    /**
      * Generic converter to read data from a single file (routes.txt, trips.txt, etc.) from file and write to dynamo.
      *
      * @param <T>      an Attributes class used to map against .csv file passed in. Should be
@@ -214,6 +256,7 @@ public class GtfsStaticParserService {
                 .with(CsvParser.Feature.TRIM_SPACES)
                 .readValues(file)) {
             List<GtfsStaticData> gtfsList = new ArrayList<>(100);
+            boolean isStopTimes = false;
             while (attributesIterator.hasNext()) {
                 T attributes = attributesIterator.next();
                 if (attributes instanceof RoutesAttributes)
@@ -222,13 +265,18 @@ public class GtfsStaticParserService {
                     gtfsList.add(convert((StopAttributes) attributes, agencyId, stopIdToNameMap));
                 else if (attributes instanceof TripAttributes)
                     gtfsList.add(convert((TripAttributes) attributes, agencyId, routeIdToNameMap, tripIdToNameMap));
-                else if (attributes instanceof StopTimeAttributes)
+                else if (attributes instanceof StopTimeAttributes) {
                     gtfsList.add(convert((StopTimeAttributes) attributes, agencyId, tripIdToNameMap, stopIdToNameMap));
+                    isStopTimes = true;
+                }
                 else {
                     //this shouldn't be possible if you code it right... famous last words
                     log.error("UNRECOGNIZED TYPE OF ATTRIBUTE, FAST FAIL.");
                     attributesIterator.close();
                 }
+            }
+            if (isStopTimes) {
+                interpolateDelay(gtfsList);
             }
             gtfsStaticRepository.saveAll(gtfsList);
         } catch (IOException e) {

--- a/src/main/java/com/doug/projects/transitdelayservice/util/TransitDateUtil.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/util/TransitDateUtil.java
@@ -1,7 +1,11 @@
 package com.doug.projects.transitdelayservice.util;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.time.*;
 import java.util.AbstractMap;
+
+import static org.apache.commons.lang3.math.NumberUtils.toInt;
 
 public class TransitDateUtil {
     public static long getMidnightSixDaysAgo() {
@@ -38,9 +42,22 @@ public class TransitDateUtil {
      */
     public static long calculateTimeDifferenceInSeconds(String expectedTime, long actualTimestamp, String timeZoneId) throws DateTimeException {
         ZoneId timezone = ZoneId.of(timeZoneId);
+        expectedTime = replaceGreaterThan24Hr(expectedTime);
         LocalTime time = LocalTime.parse(expectedTime);
         LocalDate date = LocalDate.ofInstant(Instant.ofEpochSecond(actualTimestamp), timezone);
         ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, timezone);
         return actualTimestamp - zonedDateTime.toEpochSecond();
+    }
+
+    public static @NotNull String replaceGreaterThan24Hr(String expectedTime) {
+        String hr = expectedTime.split(":")[0];
+        if (toInt(hr) > 23) {
+            String newHr = String.valueOf(toInt(hr) % 24);
+            if (newHr.length() == 1) {
+                newHr = "0" + newHr;
+            }
+            expectedTime = expectedTime.replace(hr, newHr);
+        }
+        return expectedTime;
     }
 }

--- a/src/test/java/com/doug/projects/transitdelayservice/service/CronServiceTest.java
+++ b/src/test/java/com/doug/projects/transitdelayservice/service/CronServiceTest.java
@@ -34,7 +34,7 @@ class CronServiceTest {
     private AgencyRouteTimestampRepository routeTimestampRepository;
     @Mock
     private GtfsRetryOnFailureService retryOnFailureService;
-    private final Executor rtExec = Executors.newSingleThreadExecutor();
+    private final Executor executor = Executors.newSingleThreadExecutor();
 
     private static List<AgencyFeed> getAgencyFeedList() {
         return List.of(getAgencyFeedActive());
@@ -73,7 +73,8 @@ class CronServiceTest {
                 .thenReturn(getAgencyFeedList());
         when(rtResponseService.convertFromAsync(eq(getAgencyFeedActive()), anyInt()))
                 .thenReturn(CompletableFuture.completedFuture(getResponse()));
-        ReflectionTestUtils.setField(cronService, "realtimeExecutor", rtExec);
+        ReflectionTestUtils.setField(cronService, "retryExecutor", executor);
+        ReflectionTestUtils.setField(cronService, "dynamoExecutor", executor);
         cronService.writeGtfsRealtimeData();
         verify(agencyFeedRepository, times(1)).getAgencyFeedsByStatus(eq(ACTIVE));
         verify(rtResponseService, times(1)).convertFromAsync(eq(getAgencyFeedActive()), anyInt());

--- a/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
+++ b/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
@@ -87,6 +87,17 @@ class GtfsStaticParserServiceTest {
     }
 
     @Test
+    void interpolateOver24Hrs() {
+        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("25:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
+        GtfsStaticData data3 = GtfsStaticData.builder().id("").departureTime("26:00:00").build();
+        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3));
+        assertEquals("25:00:00", data1.getDepartureTime());
+        assertEquals("01:30:00", data2.getDepartureTime());
+        assertEquals("26:00:00", data3.getDepartureTime());
+    }
+
+    @Test
     void interpolateDelayEmptyList() {
         GtfsStaticParserService.interpolateDelay(emptyList());
     }

--- a/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
+++ b/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GtfsStaticParserServiceTest {
@@ -26,6 +27,12 @@ class GtfsStaticParserServiceTest {
         MockitoAnnotations.openMocks(this);
     }
 
+    @Test
+    void interpolateDelayOneStop() {
+        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
+        GtfsStaticParserService.interpolateDelay(List.of(data1));
+        assertEquals("05:00:00", data1.getDepartureTime());
+    }
     @Test
     void interpolateDelayTwoStops() {
         GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
@@ -61,11 +68,26 @@ class GtfsStaticParserServiceTest {
 
     @Test
     void interpolateDelayNullStartOrEnd() {
-
+        GtfsStaticData data1 = GtfsStaticData.builder().id("").arrivalTime("06:00:00").departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
+        GtfsStaticData data3 = GtfsStaticData.builder().id("").departureTime("05:01:00").build();
+        GtfsStaticData data4 = GtfsStaticData.builder().id("").build();
+        GtfsStaticData data5 = GtfsStaticData.builder().id("").arrivalTime("06:02:00").departureTime("05:02:00").build();
+        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3, data4, data5));
+        assertEquals("05:00:00", data1.getDepartureTime());
+        assertEquals("05:00:30", data2.getDepartureTime());
+        assertEquals("05:01:00", data3.getDepartureTime());
+        assertEquals("05:01:30", data4.getDepartureTime());
+        assertEquals("05:02:00", data5.getDepartureTime());
+        assertEquals("06:00:00", data1.getArrivalTime());
+        assertEquals("06:00:30", data2.getArrivalTime());
+        assertEquals("06:01:00", data3.getArrivalTime());
+        assertEquals("06:01:30", data4.getArrivalTime());
+        assertEquals("06:02:00", data5.getArrivalTime());
     }
 
     @Test
     void interpolateDelayEmptyList() {
-
+        GtfsStaticParserService.interpolateDelay(emptyList());
     }
 }

--- a/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
+++ b/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
@@ -1,0 +1,71 @@
+package com.doug.projects.transitdelayservice.service;
+
+import com.doug.projects.transitdelayservice.entity.dynamodb.GtfsStaticData;
+import com.doug.projects.transitdelayservice.repository.AgencyFeedRepository;
+import com.doug.projects.transitdelayservice.repository.GtfsStaticRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GtfsStaticParserServiceTest {
+    @Mock
+    private GtfsStaticRepository gtfsStaticRepository;
+    @Mock
+    private AgencyFeedRepository agencyFeedRepository;
+    @InjectMocks
+    private GtfsStaticParserService staticParserService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void interpolateDelayTwoStops() {
+        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().id("").departureTime("05:01:00").build();
+        GtfsStaticParserService.interpolateDelay(List.of(data1, data2));
+        assertEquals("05:00:00", data1.getDepartureTime());
+        assertEquals("05:01:00", data2.getDepartureTime());
+    }
+
+    @Test
+    void interpolateDelayOneNullStop() {
+        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
+        GtfsStaticData data3 = GtfsStaticData.builder().id("").departureTime("05:02:00").build();
+        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3));
+        assertEquals("05:00:00", data1.getDepartureTime());
+        assertEquals("05:01:00", data2.getDepartureTime());
+        assertEquals("05:02:00", data3.getDepartureTime());
+    }
+
+    @Test
+    void interpolateDelayTwoBlanks() {
+        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
+        GtfsStaticData data3 = GtfsStaticData.builder().id("").build();
+        GtfsStaticData data4 = GtfsStaticData.builder().id("").departureTime("05:01:30").build();
+        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3, data4));
+        assertEquals("05:00:00", data1.getDepartureTime());
+        assertEquals("05:00:30", data2.getDepartureTime());
+        assertEquals("05:01:00", data3.getDepartureTime());
+        assertEquals("05:01:30", data4.getDepartureTime());
+    }
+
+    @Test
+    void interpolateDelayNullStartOrEnd() {
+
+    }
+
+    @Test
+    void interpolateDelayEmptyList() {
+
+    }
+}

--- a/src/test/java/com/doug/projects/transitdelayservice/util/TransitDateUtilTest.java
+++ b/src/test/java/com/doug/projects/transitdelayservice/util/TransitDateUtilTest.java
@@ -58,5 +58,9 @@ class TransitDateUtilTest {
         assertEquals(-60, timeBefore);
         long newTZ = calculateTimeDifferenceInSeconds("15:09:26", 1714342166, "America/Los_Angeles");
         assertEquals(0, newTZ);
+        long over24Hrs = calculateTimeDifferenceInSeconds("29:26:19", 1714559179, "America/Chicago");
+        assertEquals(0, over24Hrs);
+        long over24HrsFormatted = calculateTimeDifferenceInSeconds("05:26:19", 1714559179, "America/Chicago");
+        assertEquals(0, over24HrsFormatted);
     }
 }


### PR DESCRIPTION
Sometimes, stopTimes have blank arrival/departure times, and we are expected to interpolate the values. This PR adds functionality to interpolate the missing data linearly.

Also, this PR adds better non-recursive retry logic. Previously, whenever we tried to retry on dynamo timeout, we did a recursive completableFuture join. I'm not sure why, but this wasn't working. This new logic is simpler: we retry up to three times in a while loop.