### PR TITLE
Reduce memory usage during interpolation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,4 +51,4 @@ services:
     networks:
       credentials_network:
         ipv4_address: "169.254.170.3"
-    mem_limit: 512mb
+    mem_limit: 2056mb

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.12</version>
+		<version>3.2.5</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.doug.projects</groupId>
@@ -80,6 +80,17 @@
             <groupId>org.mobilitydata</groupId>
             <artifactId>gtfs-realtime-bindings</artifactId>
             <version>0.0.8</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>3.25.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.zeroturnaround</groupId>

--- a/src/main/java/com/doug/projects/transitdelayservice/entity/dynamodb/GtfsStaticData.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/entity/dynamodb/GtfsStaticData.java
@@ -40,6 +40,7 @@ public class GtfsStaticData {
     }
 
     public @Nullable TYPE getType() {
+        if (agencyType == null) return null;
         String[] split = agencyType.split(":");
         if (split.length <= 1) {
             return null;

--- a/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
@@ -51,7 +51,6 @@ public class CronService {
 
     /**
      * Writes all ACT agency's data to DynamoDb for processing.
-     * Done asynchronously to avoid blocking scheduler thread.
      */
     @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
     public void writeGtfsRealtimeData() {

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GetDelayService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GetDelayService.java
@@ -4,7 +4,6 @@ import com.doug.projects.transitdelayservice.entity.GraphOptions;
 import com.doug.projects.transitdelayservice.entity.LineGraphDataResponse;
 import com.doug.projects.transitdelayservice.entity.dynamodb.AgencyRouteTimestamp;
 import com.doug.projects.transitdelayservice.repository.AgencyRouteTimestampRepository;
-import com.doug.projects.transitdelayservice.repository.GtfsStaticRepository;
 import com.doug.projects.transitdelayservice.util.LineGraphUtil;
 import com.doug.projects.transitdelayservice.util.RouteTimestampUtil;
 import com.doug.projects.transitdelayservice.util.TransitDateUtil;
@@ -28,7 +27,6 @@ import static com.doug.projects.transitdelayservice.util.LineGraphUtil.getColumn
 @Slf4j
 public class GetDelayService {
     private final AgencyRouteTimestampRepository repository;
-    private final GtfsStaticRepository gtfsStaticRepository;
     private final LineGraphUtil lineGraphUtil;
 
 
@@ -99,7 +97,7 @@ public class GetDelayService {
         final List<String> finalRoutes = CollectionUtils.isEmpty(graphOptions.getRoutes()) ? Collections.emptyList() : graphOptions.getRoutes();
         final boolean useGtfsColor = graphOptions.getUseColor() == null || graphOptions.getUseColor(); //default to false unless specified
         if (startTime >= endTime)
-            throw new IllegalArgumentException("startTime must be greater than endTime");
+            return Mono.error(new IllegalArgumentException("StartTime must be less than endTime"));
 
         return repository.getRouteTimestampsMapBy(startTime, endTime, finalRoutes, feedId).map(routeTimestampsMap -> {
             return routeTimestampsMap.entrySet().parallelStream().map(routeFriendlyName -> {

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserService.java
@@ -207,7 +207,7 @@ public class GtfsStaticParserService {
      */
     public static void interpolateDelay(List<GtfsStaticData> gtfsList) {
         gtfsList.sort(Comparator.comparing(GtfsStaticData::getId, Comparator.nullsLast(Comparator.naturalOrder()))
-                .thenComparing(GtfsStaticData::getStopSequence));
+                .thenComparing(GtfsStaticData::getStopSequence, Comparator.nullsLast(Comparator.naturalOrder())));
         int startDepartureIndex = 0;
         int startArrivalIndex = 0;
         for (int i = 1; i < gtfsList.size(); i++) {
@@ -220,12 +220,12 @@ public class GtfsStaticParserService {
                     Duration difference = Duration.between(startTime, endTime).dividedBy(i - startDepartureIndex);
                     for (int j = startDepartureIndex + 1; j < i; j++) {
                         GtfsStaticData gtfsStaticData = gtfsList.get(j);
-                        gtfsStaticData.setDepartureTime(startTime.plus(difference.multipliedBy(j + 1))
+                        gtfsStaticData.setDepartureTime(startTime.plus(difference.multipliedBy(j - startDepartureIndex))
                                 .format(staticScheduleTimeFormatter));
                     }
                 } catch (DateTimeParseException ignored) {
                 } finally {
-                    startArrivalIndex = i;
+                    startDepartureIndex = i;
                 }
             }
             if (isNotEmpty(sameTripStop.getArrivalTime())) {
@@ -237,7 +237,7 @@ public class GtfsStaticParserService {
                             .dividedBy(i - startArrivalIndex);
                     for (int j = startArrivalIndex + 1; j < i; j++) {
                         GtfsStaticData gtfsStaticData = gtfsList.get(j);
-                        gtfsStaticData.setArrivalTime(startTime.plus(difference.multipliedBy(j + 1))
+                        gtfsStaticData.setArrivalTime(startTime.plus(difference.multipliedBy(j - startArrivalIndex))
                                 .format(staticScheduleTimeFormatter));
                     }
                 } catch (DateTimeParseException ignored) {

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserService.java
@@ -25,10 +25,7 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -36,7 +33,6 @@ import static com.doug.projects.transitdelayservice.entity.dynamodb.GtfsStaticDa
 import static com.doug.projects.transitdelayservice.util.TransitDateUtil.replaceGreaterThan24Hr;
 import static com.doug.projects.transitdelayservice.util.UrlRedirectUtil.handleRedirect;
 import static io.micrometer.common.util.StringUtils.isNotEmpty;
-import static java.util.stream.Collectors.groupingBy;
 
 @Service
 @RequiredArgsConstructor
@@ -210,35 +206,43 @@ public class GtfsStaticParserService {
      * @param gtfsList the gtfsList to be modified by this method
      */
     public static void interpolateDelay(List<GtfsStaticData> gtfsList) {
-        for (List<GtfsStaticData> sameTripStops : gtfsList.stream().collect(groupingBy(GtfsStaticData::getId)).values()) {
-            int startDepartureIndex = 0;
-            int startArrivalIndex = 0;
-            for (int i = 1; i < sameTripStops.size(); i++) {
-                GtfsStaticData sameTripStop = sameTripStops.get(i);
-                if (isNotEmpty(sameTripStop.getDepartureTime())) {
-                    LocalTime startTime = LocalTime.parse(replaceGreaterThan24Hr(sameTripStops.get(startDepartureIndex).getDepartureTime()));
+        gtfsList.sort(Comparator.comparing(GtfsStaticData::getId, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(GtfsStaticData::getStopSequence));
+        int startDepartureIndex = 0;
+        int startArrivalIndex = 0;
+        for (int i = 1; i < gtfsList.size(); i++) {
+            GtfsStaticData sameTripStop = gtfsList.get(i);
+            if (isNotEmpty(sameTripStop.getDepartureTime())) {
+                try {
+                    LocalTime startTime = LocalTime.parse(replaceGreaterThan24Hr(gtfsList.get(startDepartureIndex)
+                            .getDepartureTime()));
                     LocalTime endTime = LocalTime.parse(replaceGreaterThan24Hr(sameTripStop.getDepartureTime()));
                     Duration difference = Duration.between(startTime, endTime).dividedBy(i - startDepartureIndex);
-                    for (GtfsStaticData gtfsStaticData : sameTripStops.subList(startDepartureIndex + 1, i)) {
-                        gtfsStaticData.setDepartureTime(startTime.plus(difference).format(staticScheduleTimeFormatter));
-                        difference = difference.plus(difference);
+                    for (int j = startDepartureIndex + 1; j < i; j++) {
+                        GtfsStaticData gtfsStaticData = gtfsList.get(j);
+                        gtfsStaticData.setDepartureTime(startTime.plus(difference.multipliedBy(j + 1))
+                                .format(staticScheduleTimeFormatter));
                     }
-                    startDepartureIndex = i;
+                } catch (DateTimeParseException ignored) {
+                } finally {
+                    startArrivalIndex = i;
                 }
-                if (isNotEmpty(sameTripStop.getArrivalTime())) {
-                    try {
-                        LocalTime startTime = LocalTime.parse(replaceGreaterThan24Hr(sameTripStops.get(startArrivalIndex).getArrivalTime()));
-                        LocalTime endTime = LocalTime.parse(replaceGreaterThan24Hr(sameTripStop.getArrivalTime()));
-                        Duration difference = Duration.between(startTime, endTime).dividedBy(i - startArrivalIndex);
-                        List<GtfsStaticData> subList = sameTripStops.subList(startArrivalIndex + 1, i);
-                        for (int j = 0; j < subList.size(); j++) {
-                            GtfsStaticData gtfsStaticData = subList.get(j);
-                            gtfsStaticData.setArrivalTime(startTime.plus(difference.multipliedBy(j + 1)).format(staticScheduleTimeFormatter));
-                        }
-                    } catch (DateTimeParseException ignored) {
-                    } finally {
-                        startArrivalIndex = i;
+            }
+            if (isNotEmpty(sameTripStop.getArrivalTime())) {
+                try {
+                    LocalTime startTime = LocalTime.parse(replaceGreaterThan24Hr(gtfsList.get(startArrivalIndex)
+                            .getArrivalTime()));
+                    LocalTime endTime = LocalTime.parse(replaceGreaterThan24Hr(sameTripStop.getArrivalTime()));
+                    Duration difference = Duration.between(startTime, endTime)
+                            .dividedBy(i - startArrivalIndex);
+                    for (int j = startArrivalIndex + 1; j < i; j++) {
+                        GtfsStaticData gtfsStaticData = gtfsList.get(j);
+                        gtfsStaticData.setArrivalTime(startTime.plus(difference.multipliedBy(j + 1))
+                                .format(staticScheduleTimeFormatter));
                     }
+                } catch (DateTimeParseException ignored) {
+                } finally {
+                    startArrivalIndex = i;
                 }
             }
         }
@@ -263,7 +267,7 @@ public class GtfsStaticParserService {
                 .with(schema)
                 .with(CsvParser.Feature.TRIM_SPACES)
                 .readValues(file)) {
-            List<GtfsStaticData> gtfsList = new ArrayList<>(100);
+            List<GtfsStaticData> gtfsList = new ArrayList<>();
             boolean isStopTimes = false;
             while (attributesIterator.hasNext()) {
                 T attributes = attributesIterator.next();

--- a/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
+++ b/src/test/java/com/doug/projects/transitdelayservice/service/GtfsStaticParserServiceTest.java
@@ -29,25 +29,34 @@ class GtfsStaticParserServiceTest {
 
     @Test
     void interpolateDelayOneStop() {
-        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
-        GtfsStaticParserService.interpolateDelay(List.of(data1));
+        GtfsStaticData data1 = GtfsStaticData.builder().departureTime("05:00:00").build();
+        List<GtfsStaticData> gtfsList = new java.util.ArrayList<>();
+        gtfsList.add(data1);
+        GtfsStaticParserService.interpolateDelay(gtfsList);
         assertEquals("05:00:00", data1.getDepartureTime());
     }
     @Test
     void interpolateDelayTwoStops() {
-        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
-        GtfsStaticData data2 = GtfsStaticData.builder().id("").departureTime("05:01:00").build();
-        GtfsStaticParserService.interpolateDelay(List.of(data1, data2));
+        GtfsStaticData data1 = GtfsStaticData.builder().departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().departureTime("05:01:00").build();
+        List<GtfsStaticData> gtfsList = new java.util.ArrayList<>();
+        gtfsList.add(data1);
+        gtfsList.add(data2);
+        GtfsStaticParserService.interpolateDelay(gtfsList);
         assertEquals("05:00:00", data1.getDepartureTime());
         assertEquals("05:01:00", data2.getDepartureTime());
     }
 
     @Test
     void interpolateDelayOneNullStop() {
-        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
-        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
-        GtfsStaticData data3 = GtfsStaticData.builder().id("").departureTime("05:02:00").build();
-        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3));
+        GtfsStaticData data1 = GtfsStaticData.builder().departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().build();
+        GtfsStaticData data3 = GtfsStaticData.builder().departureTime("05:02:00").build();
+        List<GtfsStaticData> gtfsList = new java.util.ArrayList<>();
+        gtfsList.add(data1);
+        gtfsList.add(data2);
+        gtfsList.add(data3);
+        GtfsStaticParserService.interpolateDelay(gtfsList);
         assertEquals("05:00:00", data1.getDepartureTime());
         assertEquals("05:01:00", data2.getDepartureTime());
         assertEquals("05:02:00", data3.getDepartureTime());
@@ -55,11 +64,16 @@ class GtfsStaticParserServiceTest {
 
     @Test
     void interpolateDelayTwoBlanks() {
-        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("05:00:00").build();
-        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
-        GtfsStaticData data3 = GtfsStaticData.builder().id("").build();
-        GtfsStaticData data4 = GtfsStaticData.builder().id("").departureTime("05:01:30").build();
-        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3, data4));
+        GtfsStaticData data1 = GtfsStaticData.builder().departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().build();
+        GtfsStaticData data3 = GtfsStaticData.builder().build();
+        GtfsStaticData data4 = GtfsStaticData.builder().departureTime("05:01:30").build();
+        List<GtfsStaticData> gtfsList = new java.util.ArrayList<>();
+        gtfsList.add(data1);
+        gtfsList.add(data2);
+        gtfsList.add(data3);
+        gtfsList.add(data4);
+        GtfsStaticParserService.interpolateDelay(gtfsList);
         assertEquals("05:00:00", data1.getDepartureTime());
         assertEquals("05:00:30", data2.getDepartureTime());
         assertEquals("05:01:00", data3.getDepartureTime());
@@ -68,12 +82,18 @@ class GtfsStaticParserServiceTest {
 
     @Test
     void interpolateDelayNullStartOrEnd() {
-        GtfsStaticData data1 = GtfsStaticData.builder().id("").arrivalTime("06:00:00").departureTime("05:00:00").build();
-        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
-        GtfsStaticData data3 = GtfsStaticData.builder().id("").departureTime("05:01:00").build();
-        GtfsStaticData data4 = GtfsStaticData.builder().id("").build();
-        GtfsStaticData data5 = GtfsStaticData.builder().id("").arrivalTime("06:02:00").departureTime("05:02:00").build();
-        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3, data4, data5));
+        GtfsStaticData data1 = GtfsStaticData.builder().arrivalTime("06:00:00").departureTime("05:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().build();
+        GtfsStaticData data3 = GtfsStaticData.builder().departureTime("05:01:00").build();
+        GtfsStaticData data4 = GtfsStaticData.builder().build();
+        GtfsStaticData data5 = GtfsStaticData.builder().arrivalTime("06:02:00").departureTime("05:02:00").build();
+        List<GtfsStaticData> gtfsList = new java.util.ArrayList<>();
+        gtfsList.add(data1);
+        gtfsList.add(data2);
+        gtfsList.add(data3);
+        gtfsList.add(data4);
+        gtfsList.add(data5);
+        GtfsStaticParserService.interpolateDelay(gtfsList);
         assertEquals("05:00:00", data1.getDepartureTime());
         assertEquals("05:00:30", data2.getDepartureTime());
         assertEquals("05:01:00", data3.getDepartureTime());
@@ -88,10 +108,14 @@ class GtfsStaticParserServiceTest {
 
     @Test
     void interpolateOver24Hrs() {
-        GtfsStaticData data1 = GtfsStaticData.builder().id("").departureTime("25:00:00").build();
-        GtfsStaticData data2 = GtfsStaticData.builder().id("").build();
-        GtfsStaticData data3 = GtfsStaticData.builder().id("").departureTime("26:00:00").build();
-        GtfsStaticParserService.interpolateDelay(List.of(data1, data2, data3));
+        GtfsStaticData data1 = GtfsStaticData.builder().departureTime("25:00:00").build();
+        GtfsStaticData data2 = GtfsStaticData.builder().build();
+        GtfsStaticData data3 = GtfsStaticData.builder().departureTime("26:00:00").build();
+        List<GtfsStaticData> gtfsList = new java.util.ArrayList<>();
+        gtfsList.add(data1);
+        gtfsList.add(data2);
+        gtfsList.add(data3);
+        GtfsStaticParserService.interpolateDelay(gtfsList);
         assertEquals("25:00:00", data1.getDepartureTime());
         assertEquals("01:30:00", data2.getDepartureTime());
         assertEquals("26:00:00", data3.getDepartureTime());


### PR DESCRIPTION
Previously, we allocated a substring when looping over & performing interpolation. Now, we just loop through the same list again without memory acccesses. We do perform a sort, which may cause issues, but that can be monitored.