### PR TITLE
Optimistically poll from data feeds, regardless of feed status

### DIFF
--- a/src/main/java/com/doug/projects/transitdelayservice/repository/AgencyFeedRepository.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/repository/AgencyFeedRepository.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -68,12 +69,12 @@ public class AgencyFeedRepository {
                 .join();
     }
 
-    public List<AgencyFeed> getAgencyFeedsByStatus(AgencyFeed.Status status) {
-        return Flux.concat(table
+    public List<AgencyFeed> getAgencyFeedsByStatus(AgencyFeed.Status... statusList) {
+        return Flux.concat(Arrays.stream(statusList).map(status -> table
                         .query(q ->
                                 q.queryConditional(
                                         QueryConditional.keyEqualTo(k -> k.partitionValue(status.toString()))))
-                        .items())
+                        .items()).toList())
                 .collectList()
                 .toFuture()
                 .join();

--- a/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/CronService.java
@@ -92,7 +92,7 @@ public class CronService {
     public void refreshOutdatedFeeds() {
         if (!doesRealtimeCronRun)
             return;
-        log.info("Starting realtime data write");
+        log.info("Starting realtime data write, with static data polling");
         CompletableFuture<?>[] allFutures =
                 agencyFeedRepository.getAgencyFeedsByStatus(OUTDATED, UNAVAILABLE)
                         .stream()
@@ -104,6 +104,6 @@ public class CronService {
 
         CompletableFuture.allOf(allFutures).join();
 
-        log.info("Finished realtime data write");
+        log.info("Finished realtime data write, with static data polling");
     }
 }

--- a/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRetryOnFailureService.java
+++ b/src/main/java/com/doug/projects/transitdelayservice/service/GtfsRetryOnFailureService.java
@@ -26,10 +26,20 @@ public class GtfsRetryOnFailureService {
     private final GtfsStaticParserService staticParserService;
     private final GtfsRealtimeParserService realtimeParserService;
 
-    public List<AgencyRouteTimestamp> reCheckFailures(AgencyRealtimeResponse realtimeResponse) {
+    public List<AgencyRouteTimestamp> pollStaticFeedIfNeeded(AgencyRealtimeResponse realtimeResponse) {
         AgencyFeed.Status feedStatus = realtimeResponse.getFeedStatus();
         AgencyFeed feed = realtimeResponse.getFeed();
         recheckFeedByStatus(feedStatus, feed);
+        if (CollectionUtils.isEmpty(realtimeResponse.getRouteTimestamps())) {
+            return Collections.emptyList();
+        }
+        return realtimeResponse.getRouteTimestamps();
+    }
+
+    public List<AgencyRouteTimestamp> updateFeedStatus(AgencyRealtimeResponse realtimeResponse) {
+        AgencyFeed.Status feedStatus = realtimeResponse.getFeedStatus();
+        AgencyFeed feed = realtimeResponse.getFeed();
+        updateFeedToStatus(feed, feedStatus);
         if (CollectionUtils.isEmpty(realtimeResponse.getRouteTimestamps())) {
             return Collections.emptyList();
         }
@@ -54,8 +64,7 @@ public class GtfsRetryOnFailureService {
     private void recheckFeedByStatus(AgencyFeed.Status feedStatus, AgencyFeed feed) {
         switch (feedStatus) {
             case ACTIVE -> {
-                if (!feed.getStatus()
-                        .equals(ACTIVE)) {
+                if (!feed.getStatus().equals(ACTIVE.toString())) {
                     updateFeedToStatus(feed, ACTIVE);
                 }
             }


### PR DESCRIPTION
change how we poll realtime feeds. Instead of trying once to repoll static data and then failing for a month, we instead try to poll the realtime feeds every 5 mins.

This may result in more reads, but should avoid the bulk of the write costs associated